### PR TITLE
Check that certificate file exists before we create the service.

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -46,6 +46,9 @@ while True:
       print('Writing vhosts.conf...', flush=True)
       f.write(template.render(services=services))
       wroteConfig = True;
+    print('Done writing config.', flush=True)
+  else:
+    print('Not writing empty config. Ensure that your letsencrypt certificates are accessible to this container.')
 
   print('Done writing config.', flush=True)
 

--- a/generate.py
+++ b/generate.py
@@ -4,6 +4,7 @@ import argparse
 import etcdlib
 import jinja2
 import os
+import os.path
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--name', help='Name of the docker host to request certificates for', default='unknown')
@@ -26,16 +27,18 @@ while True:
   defaults = fetcher.get_label('com.chameth.proxy.default')
   for container, values in fetcher.get_label('com.chameth.proxy').items():
     networks = fetcher.get_networks(container)
-    services.append({
-      'protocol': protocols[container] if container in protocols else 'http',
-      'vhosts': domains[container],
-      'host': next(iter(networks.values())), # TODO: Pick a bridge sensibly?
-      'port': values,
-      'certificate': args.cert_path % domains[container][0],
-      'trusted_certificate': args.trusted_cert_path % domains[container][0],
-      'certificate_key': args.cert_key_path % domains[container][0],
-      'default': container in defaults,
-    })
+    certfile = args.cert_path % domains[container][0];
+    if os.path.isfile(certfile):
+      services.append({
+        'protocol': protocols[container] if container in protocols else 'http',
+        'vhosts': domains[container],
+        'host': next(iter(networks.values())), # TODO: Pick a bridge sensibly?
+        'port': values,
+        'certificate': args.cert_path % domains[container][0],
+        'trusted_certificate': args.trusted_cert_path % domains[container][0],
+        'certificate_key': args.cert_key_path % domains[container][0],
+        'default': container in defaults,
+      })
 
   with open('/nginx-config/vhosts.conf', 'w') as f:
     print('Writing vhosts.conf...', flush=True)

--- a/generate.py
+++ b/generate.py
@@ -21,6 +21,7 @@ template = jinja_env.get_template('nginx.tpl')
 fetcher = etcdlib.Connection(args.etcd_host, args.etcd_port, args.etcd_prefix)
 
 while True:
+  wroteConfig = False;
   services = []
   domains = {k: v.split(',') for k, v in fetcher.get_label('com.chameth.vhost').items()}
   protocols = fetcher.get_label('com.chameth.proxy.protocol')
@@ -40,9 +41,11 @@ while True:
         'default': container in defaults,
       })
 
-  with open('/nginx-config/vhosts.conf', 'w') as f:
-    print('Writing vhosts.conf...', flush=True)
-    f.write(template.render(services=services))
+  if wroteConfig or len(services) > 0 or not os.path.isfile('/nginx-config/vhosts.conf'):
+    with open('/nginx-config/vhosts.conf', 'w') as f:
+      print('Writing vhosts.conf...', flush=True)
+      f.write(template.render(services=services))
+      wroteConfig = True;
 
   print('Done writing config.', flush=True)
 


### PR DESCRIPTION
This closes csmith/docker-service-nginx#2

Requires that `letsencrypt-data` volume is mounted at /letsencrypt in csmith/docker-automatic-nginx-letsencrypt