### PR TITLE
Add support for load-balancing containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ are understood:
 * `com.chameth.vhost=<host>` -- the virtual host that the proxy will accept
   connections on. You can specify alternate hosts/aliases by separating them
   with commas.
+* `com.chameth.proxy.loadbalance=<gruop name>` -- Load balance this container
+  with other containers that have the same group name.
 
 ## Usage
 

--- a/generate.py
+++ b/generate.py
@@ -22,23 +22,30 @@ fetcher = etcdlib.Connection(args.etcd_host, args.etcd_port, args.etcd_prefix)
 
 while True:
   wroteConfig = False;
-  services = []
+  services = {}
   domains = {k: v.split(',') for k, v in fetcher.get_label('com.chameth.vhost').items()}
   protocols = fetcher.get_label('com.chameth.proxy.protocol')
   defaults = fetcher.get_label('com.chameth.proxy.default')
+  loadbalance = fetcher.get_label('com.chameth.proxy.loadbalance')
   for container, values in fetcher.get_label('com.chameth.proxy').items():
     networks = fetcher.get_networks(container)
     certfile = args.cert_path % domains[container][0];
+    up = 'lb_' + loadbalance[container] if container in loadbalance else 'ct_' + container
     if os.path.isfile(certfile):
-      services.append({
-        'protocol': protocols[container] if container in protocols else 'http',
-        'vhosts': domains[container],
+      if not up in services:
+        services[up] = {
+          'protocol': protocols[container] if container in protocols else 'http',
+          'vhosts': domains[container],
+          'hosts': [],
+          'certificate': args.cert_path % domains[container][0],
+          'trusted_certificate': args.trusted_cert_path % domains[container][0],
+          'certificate_key': args.cert_key_path % domains[container][0],
+          'default': container in defaults,
+        }
+
+      services[up]['hosts'].append({
         'host': next(iter(networks.values())), # TODO: Pick a bridge sensibly?
         'port': values,
-        'certificate': args.cert_path % domains[container][0],
-        'trusted_certificate': args.trusted_cert_path % domains[container][0],
-        'certificate_key': args.cert_key_path % domains[container][0],
-        'default': container in defaults,
       })
 
   if wroteConfig or len(services) > 0 or not os.path.isfile('/nginx-config/vhosts.conf'):

--- a/nginx.tpl
+++ b/nginx.tpl
@@ -1,4 +1,10 @@
-{% for service in services %}
+{% for srvname, service in services.items() %}
+upstream {{ service.upstream }} {
+{% for upstream in service.hosts %}
+        server {{ upstream.host }}:{{ upstream.port }};
+{% endfor %}
+}
+
 server {
     server_name {{ ' '.join(service.vhosts) }};
     listen [::]:443{{ ' default_server' if service.default }} ssl http2;
@@ -11,7 +17,7 @@ server {
     include /etc/nginx/conf.d/{{ service.vhosts[0] }}/*.conf;
 
     location / {
-        proxy_pass {{ service.protocol }}://{{ service.host }}:{{ service.port }};
+        proxy_pass {{ service.protocol }}://{{ service.upstream }};
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $remote_addr;
     }


### PR DESCRIPTION
Closes csmith/docker-automatic-nginx-letsencrypt#8
    
This changes the generated config to create an `upstream` block for each service and then reference that within the `server` block.
    
Multiple containers can be grouped together (so that all their hosts are added within the same `upstream` block) by adding a new label to the container with the key `com.chameth.proxy.loadbalance` and the value as the name of the `upstream` block (This will be prefixed with `lb_` for uniqueness)
    
If no `loadbalance` label is provided, then the container name is used for the `upstream` block name (prefixed with `ct_` for uniqueness)
    
The `server` block (which defines the certificate name and the vhosts) is built based on the first container found with a given `upstream` block name,  so it is reccomended that all containers that are being balanced together should have the same vhosts.
